### PR TITLE
[Backend] Add proper error handling in MongoDBWorker

### DIFF
--- a/webforces/server/mongodbworker.py
+++ b/webforces/server/mongodbworker.py
@@ -15,15 +15,20 @@ class MongoDBWorker(dbworker.DBWorker):
             logger.error("Databate is already connected!")
         self.client = pymongo.MongoClient(MONGODB_PROPERTIES['production_url'])
         self.db = self.client.webforces
-        logger.debug(f"DBWorker is connected to {MONGODB_PROPERTIES['production_url']}")
-        # <PLACEHOLDER>
-        if "stats" not in self.db.list_collection_names():
-            stats_collection = self.db["stats"]
-            stats_collection.insert_one({
-                "name": "webforces",
-            })
-        # </PLACEHOLDER>
-        return 0
+        try:
+            # <PLACEHOLDER>
+            if "stats" not in self.db.list_collection_names():
+                stats_collection = self.db["stats"]
+                stats_collection.insert_one({
+                    "name": "webforces",
+                })
+            # </PLACEHOLDER>
+        except Exception as e:
+            logger.error(f"MongoDBWorker connection failed: {e}")
+            return 1
+        else:
+            logger.debug(f"MongoDBWorker is connected to {MONGODB_PROPERTIES['production_url']}")
+            return 0
 
     def disconnect(self) -> int:
         return 0


### PR DESCRIPTION
Creation of MongoClient object does not perform real connection.
To check whether database is available we need to try to get/set something
inside it.