### PR TITLE
Suppress pytest warning on Test class

### DIFF
--- a/webforces/server/structs.py
+++ b/webforces/server/structs.py
@@ -63,6 +63,11 @@ class Test:
         )
 
 
+Test.__test__ = False
+# Added to suppress pytest collection warning:
+# cannot collect test class 'Test' because it has a __init__ constructor
+
+
 @dataclass
 class Task:
     task_id: int


### PR DESCRIPTION
pytest tries detects test classes with pattern 'Test*'
class Test from structs.py matches this pattern and it leads to the warning.
This commit suppresses this warning.