### PR TITLE
[Backend] Use list_collection_names instead of collection_names

### DIFF
--- a/webforces/server/mongodbworker.py
+++ b/webforces/server/mongodbworker.py
@@ -20,7 +20,7 @@ class MongoDBWorker(dbworker.DBWorker):
             self.db_url = MONGODB_PROPERTIES['validation_url']
             self.db_name = "webforces_val"
         self.connect()
-        if not validation and "id" not in self.db.collection_names():
+        if not validation and "id" not in self.db.list_collection_names():
             self._populateIds()
 
     def connect(self) -> int:


### PR DESCRIPTION
webforces/webforces/server/mongodbworker.py:23: DeprecationWarning: collection_names is deprecated. Use list_collection_names instead